### PR TITLE
Implemented logic for setting up config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
 *.db
+config.json
 bp-engine
 __debug_bin

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bp-engine/internal/api"
+	"bp-engine/internal/config"
+	"flag"
 	"os"
 
 	"github.com/gofiber/contrib/swagger"
@@ -24,18 +26,89 @@ import (
 // @BasePath /
 func main() {
 	environment := os.Getenv("ENV")
-	// github.com/mattn/go-sqlite3
-	db, err := gorm.Open(sqlite.Open("gorm.db"), &gorm.Config{})
+	confFilePath := os.Getenv("CONFIG_FILE")
+	migrateDbFlag := flag.Bool("migrate", false, "run DB migration scripts")
+	serveFlag := flag.Bool("serve", true, "run http server")
 
+	flag.Parse()
+	migrateDB := migrateDbFlag != nil && *migrateDbFlag
+	serveHTTP := serveFlag != nil && *serveFlag
+
+	// load config
+	conf, err := loadConfig(confFilePath, environment)
+	if err != nil {
+		log.Fatal("cannot load config file. ", err)
+	}
+
+	// connect to db
+	// github.com/mattn/go-sqlite3
+	db, err := gorm.Open(sqlite.Open(conf.DbUrl), &gorm.Config{})
 	if err != nil {
 		log.Fatal("cannot connect to db", err)
 	}
 
-	db.AutoMigrate(&api.Process{})
-	db.AutoMigrate(&api.ProcessStatus{})
+	if migrateDB {
+		log.Info("run DB migration")
+		if migrationErr := runDBMigration(db); len(migrationErr) > 0 {
+			for _, e := range migrationErr {
+				log.Error("DB migration error", e)
+			}
+			log.Fatal("cannot successfully complete DB migration")
+		}
+		log.Info("DB migration done!")
+		os.Exit(0)
+	}
 
+	if serveHTTP {
+		app := setupApp(conf, db)
+		log.Fatal(app.Listen(":3000"))
+	}
+
+	// pathToSwaggerFile := "./docs/swagger.json"
+	// if len(environment) == 0 || environment == "dev" {
+	// 	pathToSwaggerFile = "../docs/swagger.json"
+	// }
+	// cfg := swagger.Config{
+	// 	BasePath: "/",
+	// 	FilePath: pathToSwaggerFile,
+	// 	Path:     "swagger",
+	// 	Title:    "Swagger API Docs",
+	// }
+
+	// app := fiber.New()
+	// app.Use(fiberlogger.New())
+	// app.Use(swagger.New(cfg))
+
+	// processRepository := api.NewProcessRepository(db)
+	// processService := api.NewProcessService(processRepository)
+	// processController := api.NewProcessController(processService)
+
+	// api := app.Group("/api")
+	// v1 := api.Group("/v1")
+
+	// v1.Get("/health", Health)
+	// processController.SetupRouter(v1.Group("/process"))
+
+	// log.Fatal(app.Listen(":3000"))
+}
+
+// @Summary Show the status of server.
+// @Description get the status of server.
+// @Tags root
+// @Accept */*
+// @Produce json
+// @Success 200 {object} map[string]interface{}
+// @Router /v1/Health [get]
+func Health(c *fiber.Ctx) error {
+	return c.JSON(fiber.Map{
+		"status": "OK",
+	})
+}
+
+func setupApp(conf *config.Config, db *gorm.DB) *fiber.App {
+	// Swagger config
 	pathToSwaggerFile := "./docs/swagger.json"
-	if len(environment) == 0 || environment == "dev" {
+	if len(conf.Env) == 0 || conf.Env == "dev" {
 		pathToSwaggerFile = "../docs/swagger.json"
 	}
 	cfg := swagger.Config{
@@ -45,6 +118,7 @@ func main() {
 		Title:    "Swagger API Docs",
 	}
 
+	// Fiber App init
 	app := fiber.New()
 	app.Use(fiberlogger.New())
 	app.Use(swagger.New(cfg))
@@ -59,18 +133,29 @@ func main() {
 	v1.Get("/health", Health)
 	processController.SetupRouter(v1.Group("/process"))
 
-	log.Fatal(app.Listen(":3000"))
+	return app
 }
 
-// @Summary Show the status of server.
-// @Description get the status of server.
-// @Tags root
-// @Accept */*
-// @Produce json
-// @Success 200 {object} map[string]interface{}
-// @Router /v1/Health [get]
-func Health(c *fiber.Ctx) error {
-	return c.JSON(fiber.Map{
-		"status": "OK",
-	})
+func loadConfig(filePath, environment string) (*config.Config, error) {
+	if len(filePath) == 0 {
+		filePath = config.DEFAULT_CONFIG_FILEPATH
+	}
+	cb := config.NewConfigBuilder().WithConfigFile(filePath)
+	cf, err := cb.LoadConfig()
+	if err == nil {
+		cf.Env = environment
+	}
+	return cf, err
+}
+
+func runDBMigration(db *gorm.DB) []error {
+	var migrationErr []error
+	if dbErr := db.AutoMigrate(&api.Process{}); dbErr != nil {
+		migrationErr = append(migrationErr, dbErr)
+	}
+	if dbErr := db.AutoMigrate(&api.ProcessStatus{}); dbErr != nil {
+		migrationErr = append(migrationErr, dbErr)
+	}
+
+	return migrationErr
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ type (
 
 	Config struct {
 		filePath      string          `json:"-"`
+		DbUrl         string          `json:"db_url"`
 		ProcessConfig []ProcessConfig `json:"processes"`
 	}
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+type (
+	FileReader interface {
+		ReadFile(filePath string) ([]byte, error)
+	}
+
+	Config struct {
+		filePath      string          `json:"-"`
+		ProcessConfig []ProcessConfig `json:"processes"`
+	}
+)
+
+const DEFAULT_CONFIG_FILEPATH = "./config.json"
+
+var ErrConfigFileIsEmpty = errors.New("Config file is empty")
+
+func (c *Config) LoadConfig(fileReader FileReader) (*Config, error) {
+	var conf Config
+
+	content, err := fileReader.ReadFile(c.filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(content) <= 0 {
+		return nil, ErrConfigFileIsEmpty
+	}
+
+	err = json.Unmarshal(content, &conf)
+	if err != nil {
+		return nil, err
+	}
+
+	return &conf, nil
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,130 @@
+package config
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockedFileReader struct {
+	mock.Mock
+}
+
+func (fr *mockedFileReader) ReadFile(filePath string) ([]byte, error) {
+	args := fr.Called(filePath)
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+func Test_LoadConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		wantErr  error
+		wantConf *Config
+		mockFunc func() FileReader
+	}{
+		{
+			name: "success",
+			mockFunc: func() FileReader {
+				fr := mockedFileReader{}
+				fr.On("ReadFile", mock.Anything).
+					Return(
+						[]byte(`
+					{
+						"statuses": [
+							{
+								"name": "open",
+								"next": [
+									"in_progress",
+									"rejected"
+								]
+							},
+							{
+								"name": "in_progress",
+								"next": [
+									"open",
+									"rejected"
+								]
+							},
+							{
+								"name": "rejected"
+							}
+						]
+					}					
+					`), nil)
+				return &fr
+			},
+			wantConf: &Config{
+				ProcessConfig: []ProcessConfig{
+					{
+						Name: "test",
+						Statuses: []StatusConfig{
+							{
+								Name: "open",
+								Next: []string{"in_progress", "rejected"},
+							},
+							{
+								Name: "in_progress",
+								Next: []string{"open", "rejected"},
+							},
+							{
+								Name: "rejected",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "failed",
+			mockFunc: func() FileReader {
+				fr := mockedFileReader{}
+				fr.On("ReadFile", mock.Anything).
+					Return(
+						[]byte(`
+					{						
+							{
+								"name": "open",
+								"next": [
+									"in_progress",
+									"rejected"
+								]
+							},
+							{
+								"name": "in_progress",
+								"next": [
+									"open",
+									"rejected"
+								]
+							},
+							{
+								"name": "rejected"
+							}
+						]
+					}					
+					`), nil)
+				return &fr
+			},
+			wantConf: nil,
+			wantErr:  errors.New("invalid character '{' looking for beginning of object key string"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := Config{}
+			fr := tt.mockFunc()
+			gotConf, gotErr := conf.LoadConfig(fr)
+
+			if tt.wantErr != nil {
+				assert.NotNil(t, gotErr)
+				assert.Equal(t, tt.wantErr.Error(), gotErr.Error())
+			} else {
+				assert.Nil(t, gotErr)
+				assert.NotNil(t, gotConf)
+			}
+
+		})
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -117,9 +117,9 @@ func Test_LoadConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			conf := Config{}
+			conf := NewConfigBuilder()
 			fr := tt.mockFunc()
-			gotConf, gotErr := conf.LoadConfig(fr)
+			gotConf, gotErr := conf.LoadFromFile(fr)
 
 			if tt.wantErr != nil {
 				assert.NotNil(t, gotErr)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -30,8 +30,11 @@ func Test_LoadConfig(t *testing.T) {
 				fr := mockedFileReader{}
 				fr.On("ReadFile", mock.Anything).
 					Return(
-						[]byte(`
+						[]byte(`{
+					"db_url": "gorm.db",
+					"processes": [
 					{
+						"name": "requests",
 						"statuses": [
 							{
 								"name": "open",
@@ -51,14 +54,15 @@ func Test_LoadConfig(t *testing.T) {
 								"name": "rejected"
 							}
 						]
-					}					
+					}]		}
 					`), nil)
 				return &fr
 			},
 			wantConf: &Config{
+				DbUrl: "gorm.db",
 				ProcessConfig: []ProcessConfig{
 					{
-						Name: "test",
+						Name: "requests",
 						Statuses: []StatusConfig{
 							{
 								Name: "open",
@@ -123,6 +127,7 @@ func Test_LoadConfig(t *testing.T) {
 			} else {
 				assert.Nil(t, gotErr)
 				assert.NotNil(t, gotConf)
+				assert.Equal(t, tt.wantConf, gotConf)
 			}
 
 		})

--- a/internal/config/model.go
+++ b/internal/config/model.go
@@ -1,0 +1,13 @@
+package config
+
+type (
+	ProcessConfig struct {
+		Name     string         `json:"name"`
+		Statuses []StatusConfig `json:"statuses"`
+	}
+
+	StatusConfig struct {
+		Name string   `json:"name"`
+		Next []string `json:"next,omitempty"`
+	}
+)

--- a/test.http
+++ b/test.http
@@ -7,7 +7,7 @@ POST http://localhost:3000/api/v1/process
 Content-Type: application/json
 
 {
-    "code": "{{code}}"
+    "code": "{{code}}",
     "payload": {
         "sample": "payload"
     }


### PR DESCRIPTION
- Load configuration from `config.json` file
- Use `--migrate` flage to run DB migrations
- Use `--serve` to run HTTP server (by default `true`)